### PR TITLE
Icon name in desktop file should be without extension

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ def make_desktop_file(app_src, desktop_dest):
               "Comment=" + config.description + "\n" \
               "Exec=" + script_path + "\n" \
               "GenericName=" + config.name + "\n" \
-              "Icon=silo-" + os.path.basename(config.icon) + "\n" \
+              "Icon=silo-" + os.path.splitext(os.path.basename(config.icon))[0] + "\n" \
               "MimeType=\n" \
               "Name=" + config.name + "\n" \
               "Path=\n" \


### PR DESCRIPTION
As per the [freedesktop specification](https://specifications.freedesktop.org/desktop-entry-spec/latest/ar01s06.html), one should use the icon name not the file name