### PR TITLE
Improve code of TrayIcon.py

### DIFF
--- a/pyqtws/plugin/TrayIcon.py
+++ b/pyqtws/plugin/TrayIcon.py
@@ -14,11 +14,6 @@ class TrayIcon(QTWSPlugin):
         super().__init__("TrayIcon")
         self.window = None
         
-        self.icon_path = tempfile.NamedTemporaryFile(suffix=".png").name
-        
-        tmp_image = QImage(config.icon)
-        tmp_image.save(self.icon_path)
-        
         self.menu = pystray.Menu(
             pystray.MenuItem(
                 "Toggle visibility", 
@@ -32,25 +27,28 @@ class TrayIcon(QTWSPlugin):
             )
         )
         
-        self.tray_icon = pystray.Icon(
-            config.name,
-            Image.open(self.icon_path),
-            menu=self.menu
-        )
+        with tempfile.NamedTemporaryFile(suffix=".png") as self.tmp_icon:
+            QImage(config.icon).save(self.tmp_icon.name)
+            
+            self.tray_icon = pystray.Icon(
+                config.name,
+                Image.open(self.tmp_icon.name),
+                menu=self.menu
+            )
         
         self.tray_icon.visible = True
         self.tray_icon.run_detached()
-                
+
     def close_event(self, window: QTWSMainWindow, event: QCloseEvent):
         self.__toggle_visibility()
         event.ignore()
 
     def window_setup(self, window: QTWSMainWindow):
         self.window = window
-            
+
     def __toggle_visibility(self):
         self.window.setVisible(not self.window.isVisible())
-    
+
     def __quit(self):
         self.tray_icon.stop()
         self.window.quit()


### PR DESCRIPTION
- Improved code readability: Tray menu is created first, then comes the icon stuff
- Skips creation of temporary QImage variable and directly saves to temporary file
- Temporary QImage file is removed after it is loaded to memory and unneeded anymore
- Improper indents from empty lines removed